### PR TITLE
Change link for PyCon Belarus: changed to workable one

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
                     <div>
                         <h3>PyCon Belarus</h3>
                         <p>
-                            <a href="https://by.pycon.org/" target="_blank" rel="noopener noreferrer">PyCon Belarus</a>
+                            <a href="https://www.linkedin.com/company/pycon-belarus/" target="_blank" rel="noopener noreferrer">PyCon Belarus</a>
                             is the biggest annual event in Belarus which is dedicated to Python
                         <br>
                         </p>


### PR DESCRIPTION
Change link for PyCon Belarus: changed to workable one (LinkedIn instead of the original website on Tilda)